### PR TITLE
Enable converting bitfield structs to int/long values

### DIFF
--- a/src/main/scala/com/foursquare/spindle/runtime/BitFieldHelpers.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/BitFieldHelpers.scala
@@ -20,9 +20,7 @@ object BitFieldHelpers {
   }
 
   def bitFieldToStruct(bitfield: Int, meta: MetaRecord[_]): meta.Trait = {
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.unsafeManifest == manifest[Boolean]))
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.id >= 1 && f.id <= 16))
-    assert(meta.fields.size <= 16)
+    verifyMeta(meta, 16)
 
     val result = meta.createRawRecord
 
@@ -53,9 +51,7 @@ object BitFieldHelpers {
   }
 
   def longBitFieldToStruct(bitfield: Long, meta: MetaRecord[_]): meta.Trait = {
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.unsafeManifest == manifest[Boolean]))
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.id >= 1 && f.id <= 31))
-    assert(meta.fields.size <= 31)
+    verifyMeta(meta, 31)
 
     val result = meta.createRawRecord
 
@@ -75,9 +71,7 @@ object BitFieldHelpers {
   }
 
   def bitFieldToStructNoSetBits(bitfield: Int, meta: MetaRecord[_]): meta.Trait = {
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.unsafeManifest == manifest[Boolean]))
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.id >= 1 && f.id <= 32))
-    assert(meta.fields.size <= 32)
+    verifyMeta(meta, 32)
 
     val result = meta.createRawRecord
 
@@ -95,9 +89,7 @@ object BitFieldHelpers {
   }
 
   def longBitFieldToStructNoSetBits(bitfield: Long, meta: MetaRecord[_]): meta.Trait = {
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.unsafeManifest == manifest[Boolean]))
-    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.id >= 1 && f.id <= 64))
-    assert(meta.fields.size <= 64)
+    verifyMeta(meta, 64)
 
     val result = meta.createRawRecord
 
@@ -107,5 +99,11 @@ object BitFieldHelpers {
     })
 
     result
+  }
+
+  private def verifyMeta(meta: MetaRecord[_], availableBits: Int) = {
+    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.unsafeManifest == manifest[Boolean]))
+    assert(meta.fields.forall((f: UntypedFieldDescriptor) => f.id >= 1 && f.id <= availableBits))
+    assert(meta.fields.size <= availableBits)
   }
 }

--- a/src/test/scala/com/foursquare/spindle/runtime/BitFieldHelpersTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/BitFieldHelpersTest.scala
@@ -3,6 +3,7 @@
 package com.foursquare.spindle.test
 
 import com.foursquare.spindle.BitFieldHelpers
+import com.foursquare.spindle.test.gen.{ChildStruct7, ChildStruct16, ChildStruct32, ChildStruct64}
 import org.junit.Test
 import org.specs.SpecsMatchers
 
@@ -19,4 +20,174 @@ class BitFieldHelpersTest extends SpecsMatchers {
     BitFieldHelpers.getLongIsSet(sanityFlags, 0) must_== true
     BitFieldHelpers.getLongValue(sanityFlags, 0) must_== false
   }
+
+  @Test
+  def toLong() {
+    s7 must_== BitFieldHelpers.bitFieldToStruct(BitFieldHelpers.structToBitField(s7), s7.meta)
+    s7 must_== BitFieldHelpers.longBitFieldToStruct(BitFieldHelpers.structToLongBitField(s7), s7.meta)
+
+    s7WithUnset must_== BitFieldHelpers.bitFieldToStruct(
+      BitFieldHelpers.structToBitField(s7WithUnset), s7WithUnset.meta)
+    s7WithUnset must_== BitFieldHelpers.longBitFieldToStruct(
+      BitFieldHelpers.structToLongBitField(s7WithUnset), s7WithUnset.meta)
+
+    s16 must_== BitFieldHelpers.bitFieldToStruct(BitFieldHelpers.structToBitField(s16), s16.meta)
+    s16 must_== BitFieldHelpers.longBitFieldToStruct(BitFieldHelpers.structToLongBitField(s16), s16.meta)
+
+    s32 must_== BitFieldHelpers.bitFieldToStructNoSetBits(BitFieldHelpers.structToBitFieldNoSetBits(s32), s32.meta)
+
+    s64 must_== BitFieldHelpers.longBitFieldToStructNoSetBits(
+      BitFieldHelpers.structToLongBitFieldNoSetBits(s64), s64.meta)
+  }
+
+  @Test
+  def toStruct() {
+    val int = 0xFFFFAA55
+    val long = 0xFFFFFFFFAAAA5555L
+
+    int must_== BitFieldHelpers.structToBitField(BitFieldHelpers.bitFieldToStruct(int, s16.meta))
+    int must_== BitFieldHelpers.structToBitFieldNoSetBits(
+      BitFieldHelpers.bitFieldToStructNoSetBits(int, s32.meta))
+
+    long must_== BitFieldHelpers.structToLongBitFieldNoSetBits(
+      BitFieldHelpers.longBitFieldToStructNoSetBits(long, s64.meta))
+  }
+
+  val s7 = ChildStruct7.newBuilder
+    .member1(true)
+    .member2(false)
+    .member3(true)
+    .member4(false)
+    .member5(true)
+    .member6(false)
+    .member7(true)
+    .result()
+
+  val s7WithUnset = ChildStruct7.newBuilder
+    .member1(true)
+    .member2(false)
+    .member3(true)
+    .member4(false)
+    .result()
+
+  val s16 = ChildStruct16.newBuilder
+    .member1(true)
+    .member2(false)
+    .member3(true)
+    .member4(false)
+    .member5(true)
+    .member6(false)
+    .member7(true)
+    .member8(false)
+    .member9(true)
+    .member10(false)
+    .member11(true)
+    .member12(false)
+    .member13(true)
+    .member14(false)
+    .member15(true)
+    .member16(false)
+    .result()
+
+  val s32 = ChildStruct32.newBuilder
+    .member1(true)
+    .member2(false)
+    .member3(true)
+    .member4(false)
+    .member5(true)
+    .member6(false)
+    .member7(true)
+    .member8(false)
+    .member9(true)
+    .member10(false)
+    .member11(true)
+    .member12(false)
+    .member13(true)
+    .member14(false)
+    .member15(true)
+    .member16(false)
+    .member17(true)
+    .member18(false)
+    .member19(true)
+    .member20(false)
+    .member21(true)
+    .member22(false)
+    .member23(true)
+    .member24(false)
+    .member25(true)
+    .member26(false)
+    .member27(true)
+    .member28(false)
+    .member29(true)
+    .member30(false)
+    .member31(true)
+    .member32(false)
+    .result()
+
+  val s64 = ChildStruct64.newBuilder
+    .member1(true)
+    .member2(false)
+    .member3(true)
+    .member4(false)
+    .member5(true)
+    .member6(false)
+    .member7(true)
+    .member8(false)
+    .member9(true)
+    .member10(false)
+    .member11(true)
+    .member12(false)
+    .member13(true)
+    .member14(false)
+    .member15(true)
+    .member16(false)
+    .member17(true)
+    .member18(false)
+    .member19(true)
+    .member20(false)
+    .member21(true)
+    .member22(false)
+    .member23(true)
+    .member24(false)
+    .member25(true)
+    .member26(false)
+    .member27(true)
+    .member28(false)
+    .member29(true)
+    .member30(false)
+    .member31(true)
+    .member32(false)
+    .member33(true)
+    .member34(false)
+    .member35(true)
+    .member36(false)
+    .member37(true)
+    .member38(false)
+    .member39(true)
+    .member40(false)
+    .member41(true)
+    .member42(false)
+    .member43(true)
+    .member44(false)
+    .member45(true)
+    .member46(false)
+    .member47(true)
+    .member48(false)
+    .member49(true)
+    .member50(false)
+    .member51(true)
+    .member52(false)
+    .member53(true)
+    .member54(false)
+    .member55(true)
+    .member56(false)
+    .member57(true)
+    .member58(false)
+    .member59(true)
+    .member60(false)
+    .member61(true)
+    .member62(false)
+    .member63(true)
+    .member64(false)
+    .result()
 }

--- a/src/test/thrift/com/foursquare/spindle/codegen/bitfield_test.thrift
+++ b/src/test/thrift/com/foursquare/spindle/codegen/bitfield_test.thrift
@@ -1,0 +1,136 @@
+// Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
+
+namespace java com.foursquare.spindle.test.gen
+
+struct ChildStruct7 {
+  1: optional bool member1
+  2: optional bool member2
+  3: optional bool member3
+  4: optional bool member4
+  5: optional bool member5
+  6: optional bool member6
+  7: optional bool member7
+}
+
+struct ChildStruct16 {
+  1: optional bool member1
+  2: optional bool member2
+  3: optional bool member3
+  4: optional bool member4
+  5: optional bool member5
+  6: optional bool member6
+  7: optional bool member7
+  8: optional bool member8
+  9: optional bool member9
+  10: optional bool member10
+  11: optional bool member11
+  12: optional bool member12
+  13: optional bool member13
+  14: optional bool member14
+  15: optional bool member15
+  16: optional bool member16
+}
+
+struct ChildStruct32 {
+  1: optional bool member1
+  2: optional bool member2
+  3: optional bool member3
+  4: optional bool member4
+  5: optional bool member5
+  6: optional bool member6
+  7: optional bool member7
+  8: optional bool member8
+  9: optional bool member9
+  10: optional bool member10
+  11: optional bool member11
+  12: optional bool member12
+  13: optional bool member13
+  14: optional bool member14
+  15: optional bool member15
+  16: optional bool member16
+  17: optional bool member17
+  18: optional bool member18
+  19: optional bool member19
+  20: optional bool member20
+  21: optional bool member21
+  22: optional bool member22
+  23: optional bool member23
+  24: optional bool member24
+  25: optional bool member25
+  26: optional bool member26
+  27: optional bool member27
+  28: optional bool member28
+  29: optional bool member29
+  30: optional bool member30
+  31: optional bool member31
+  32: optional bool member32
+}
+
+
+struct ChildStruct64 {
+  1: optional bool member1
+  2: optional bool member2
+  3: optional bool member3
+  4: optional bool member4
+  5: optional bool member5
+  6: optional bool member6
+  7: optional bool member7
+  8: optional bool member8
+  9: optional bool member9
+  10: optional bool member10
+  11: optional bool member11
+  12: optional bool member12
+  13: optional bool member13
+  14: optional bool member14
+  15: optional bool member15
+  16: optional bool member16
+  17: optional bool member17
+  18: optional bool member18
+  19: optional bool member19
+  20: optional bool member20
+  21: optional bool member21
+  22: optional bool member22
+  23: optional bool member23
+  24: optional bool member24
+  25: optional bool member25
+  26: optional bool member26
+  27: optional bool member27
+  28: optional bool member28
+  29: optional bool member29
+  30: optional bool member30
+  31: optional bool member31
+  32: optional bool member32
+  33: optional bool member33
+  34: optional bool member34
+  35: optional bool member35
+  36: optional bool member36
+  37: optional bool member37
+  38: optional bool member38
+  39: optional bool member39
+  40: optional bool member40
+  41: optional bool member41
+  42: optional bool member42
+  43: optional bool member43
+  44: optional bool member44
+  45: optional bool member45
+  46: optional bool member46
+  47: optional bool member47
+  48: optional bool member48
+  49: optional bool member49
+  50: optional bool member50
+  51: optional bool member51
+  52: optional bool member52
+  53: optional bool member53
+  54: optional bool member54
+  55: optional bool member55
+  56: optional bool member56
+  57: optional bool member57
+  58: optional bool member58
+  59: optional bool member59
+  60: optional bool member60
+  61: optional bool member61
+  62: optional bool member62
+  63: optional bool member63
+  64: optional bool member64
+}
+


### PR DESCRIPTION
Add methods to convert each type of bitfield struct to its corresponding int or long bitfield mask. Add some tests.

Depends on https://github.com/foursquare/spindle/pull/1, because the tests do not pass until that fix goes in.
