### PR TITLE
Add ability to use bitfield structs on builders

### DIFF
--- a/src/main/scala/com/foursquare/spindle/codegen/runtime/RenderType.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/runtime/RenderType.scala
@@ -338,6 +338,14 @@ case class BitfieldStructRenderType(
     case (false, TType.I64) => "com.foursquare.spindle.BitFieldHelpers.longBitFieldToStructNoSetBits"
     case _ => throw new IllegalArgumentException("Unsupported bitfield type: " + ref.ttype + " with hasSetBits: " + hasSetBits)
   }
+
+  val bitfieldWrite = (hasSetBits, ref.ttype) match {
+    case (true, TType.I32) => "com.foursquare.spindle.BitFieldHelpers.structToBitField"
+    case (true, TType.I64) => "com.foursquare.spindle.BitFieldHelpers.structToLongBitField"
+    case (false, TType.I32) => "com.foursquare.spindle.BitFieldHelpers.structToBitFieldNoSetBits"
+    case (false, TType.I64) => "com.foursquare.spindle.BitFieldHelpers.structToLongBitFieldNoSetBits"
+    case _ => throw new IllegalArgumentException("Unsupported bitfield type: " + ref.ttype + " with hasSetBits: " + hasSetBits)
+  }
 }
 
 object RenderType {

--- a/src/main/ssp/codegen/scala/class_companion_builder.ssp
+++ b/src/main/ssp/codegen/scala/class_companion_builder.ssp
@@ -34,6 +34,14 @@ val requiredTraits = requiredFields.map(field => "Has" + field.name.capitalize)
       obj.${field.escapedName}_=(v)
       this.asInstanceOf[${cls.name}.Builder[State with Builder.${trayt}]]
     }
+
+#if (field.renderType.isInstanceOf[com.foursquare.spindle.codegen.runtime.BitfieldStructRenderType])
+<% val renderType = field.renderType.asInstanceOf[com.foursquare.spindle.codegen.runtime.BitfieldStructRenderType] %>
+    def ${field.escapedName}Struct(v: ${renderType.className}): ${cls.name}.Builder[State with Builder.${trayt}] = {
+      obj.${field.escapedName}_=(${renderType.bitfieldWrite}(v))
+      this.asInstanceOf[${cls.name}.Builder[State with Builder.${trayt}]]
+    }
+#end
 #end
 #for (field <- optionalFields)
 
@@ -49,6 +57,22 @@ val requiredTraits = requiredFields.map(field => "Has" + field.name.capitalize)
       }
       this
     }
+#if (field.renderType.isInstanceOf[com.foursquare.spindle.codegen.runtime.BitfieldStructRenderType])
+<% val renderType = field.renderType.asInstanceOf[com.foursquare.spindle.codegen.runtime.BitfieldStructRenderType] %>
+
+    def ${field.escapedName}Struct(v: ${renderType.className}): ${cls.name}.Builder[State] = {
+      obj.${field.escapedName}_=(${renderType.bitfieldWrite}(v))
+      this
+    }
+
+    def ${field.escapedName}Struct(vOpt: Option[${renderType.className}]): ${cls.name}.Builder[State] = {
+      vOpt match {
+        case Some(v) => obj.${field.escapedName}_=(${renderType.bitfieldWrite}(v))
+        case None => obj.${field.name}Unset()
+      }
+      this
+    }
+#end
 #end
 
 <%

--- a/src/test/scala/com/foursquare/spindle/runtime/BitFieldHelpersTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/BitFieldHelpersTest.scala
@@ -3,7 +3,7 @@
 package com.foursquare.spindle.test
 
 import com.foursquare.spindle.BitFieldHelpers
-import com.foursquare.spindle.test.gen.{ChildStruct7, ChildStruct16, ChildStruct32, ChildStruct64}
+import com.foursquare.spindle.test.gen.{ChildStruct7, ChildStruct16, ChildStruct32, ChildStruct64, ParentStruct}
 import org.junit.Test
 import org.specs.SpecsMatchers
 
@@ -51,6 +51,27 @@ class BitFieldHelpersTest extends SpecsMatchers {
 
     long must_== BitFieldHelpers.structToLongBitFieldNoSetBits(
       BitFieldHelpers.longBitFieldToStructNoSetBits(long, s64.meta))
+  }
+
+  @Test
+  def testBuilder() {
+    ParentStruct.newBuilder.s7As32Struct(s7).result() must_==
+      ParentStruct.newBuilder.s7As32(BitFieldHelpers.structToBitField(s7)).result()
+    ParentStruct.newBuilder.s16As32Struct(s16).result() must_==
+      ParentStruct.newBuilder.s16As32(BitFieldHelpers.structToBitField(s16)).result()
+
+    ParentStruct.newBuilder.s7As64Struct(s7).result() must_==
+      ParentStruct.newBuilder.s7As64(BitFieldHelpers.structToLongBitField(s7)).result()
+
+    ParentStruct.newBuilder.s7As32NoSetStruct(s7).result() must_==
+      ParentStruct.newBuilder.s7As32NoSet(BitFieldHelpers.structToBitFieldNoSetBits(s7)).result()
+    ParentStruct.newBuilder.s32As32NoSetStruct(s32).result() must_==
+      ParentStruct.newBuilder.s32As32NoSet(BitFieldHelpers.structToBitFieldNoSetBits(s32)).result()
+
+    ParentStruct.newBuilder.s7As64NoSetStruct(s7).result() must_==
+      ParentStruct.newBuilder.s7As64NoSet(BitFieldHelpers.structToLongBitFieldNoSetBits(s7)).result()
+    ParentStruct.newBuilder.s64As64NoSetStruct(s64).result() must_==
+      ParentStruct.newBuilder.s64As64NoSet(BitFieldHelpers.structToLongBitFieldNoSetBits(s64)).result()
   }
 
   val s7 = ChildStruct7.newBuilder

--- a/src/test/thrift/com/foursquare/spindle/codegen/bitfield_test.thrift
+++ b/src/test/thrift/com/foursquare/spindle/codegen/bitfield_test.thrift
@@ -134,3 +134,13 @@ struct ChildStruct64 {
   64: optional bool member64
 }
 
+struct ParentStruct {
+  1: optional i32 s7As32 (bitfield_struct="ChildStruct7")
+  2: optional i64 s7As64 (bitfield_struct="ChildStruct7")
+  3: optional i32 s16As32 (bitfield_struct="ChildStruct16")
+  4: optional i32 s7As32NoSet (bitfield_struct_no_setbits="ChildStruct7")
+  5: optional i64 s7As64NoSet (bitfield_struct_no_setbits="ChildStruct7")
+  6: optional i32 s32As32NoSet (bitfield_struct_no_setbits="ChildStruct32")
+  7: optional i64 s64As64NoSet (bitfield_struct_no_setbits="ChildStruct64")
+}
+


### PR DESCRIPTION
Now the conversion from struct => long is taken care of in the builder. The builder will accept either a long value or a struct representing the corresponding bitfield.
