### PR TITLE
Require wire_name's to be unique

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -75,6 +75,10 @@ object SpindleBuild extends Build {
     Project(
       id = "spindle-test-parser",
       base = file("src/test/scala/com/foursquare/spindle/codegen/parser")) dependsOn(parser)
+  lazy val testCodegenBinary =
+    Project(
+      id = "spindle-test-codegen-binary",
+      base = file("src/test/scala/com/foursquare/spindle/codegen/binary")) dependsOn(codegenBinary)
   lazy val testRuntime =
     Project(
       id = "spindle-test-runtime",

--- a/src/main/scala/com/foursquare/spindle/codegen/parser/ThriftValidator.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/parser/ThriftValidator.scala
@@ -41,9 +41,6 @@ class ThriftValidator(file: File) {
   def validateFields(fields: Seq[descriptors.Field], where: String): Unit = {
     validateDistinct(fields.map(_.identifier), "field identifier(s)", Some(where))
     validateDistinct(fields.map(_.name), "field name(s)", Some(where))
-    validateDistinct(
-      fields.map(f => f.annotationsOption.flatMap(_.find(_.key == "wire_name").map(_.value)).getOrElse(f.name)),
-      "wire_name(s)", Some(where))
   }
 
   def validateDistinct[A](xs: Seq[A], what: String, where: Option[String] = None): Unit = {

--- a/src/main/scala/com/foursquare/spindle/codegen/parser/ThriftValidator.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/parser/ThriftValidator.scala
@@ -41,12 +41,15 @@ class ThriftValidator(file: File) {
   def validateFields(fields: Seq[descriptors.Field], where: String): Unit = {
     validateDistinct(fields.map(_.identifier), "field identifier(s)", Some(where))
     validateDistinct(fields.map(_.name), "field name(s)", Some(where))
+    validateDistinct(
+      fields.map(f => f.annotationsOption.flatMap(_.find(_.key == "wire_name").map(_.value)).getOrElse(f.name)),
+      "wire_name(s)", Some(where))
   }
 
   def validateDistinct[A](xs: Seq[A], what: String, where: Option[String] = None): Unit = {
     if (xs.size != xs.distinct.size) {
       val repeats = xs.diff(xs.distinct)
-      val message = 
+      val message =
         where match {
           case Some(w) =>
             "Repeated %s in %s: %s".format(what, w, repeats.mkString(", "))

--- a/src/main/scala/com/foursquare/spindle/codegen/runtime/ScalaClass.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/runtime/ScalaClass.scala
@@ -31,15 +31,19 @@ class ScalaClass(
       new ScalaField(field, resolver, isPrimaryKey, isForeignKey)
     }
 
-  // Check that no retired_ids or retired_wire_names are being used in 
+  // Check that no retired_ids or retired_wire_names are being used in
   {
     // In an extra scope to prevent these vals from being public on the class
     val ids = __fields.map(_.identifier).toSet
     val wireNames = __fields.map(_.wireName).toSet
     val retiredIds = annotations.getAll("retired_ids").flatMap(_.split(',')).map(_.toShort).toSet
     val retiredWireNames = annotations.getAll("retired_wire_names").flatMap(_.split(',')).toSet
+    val repeatedWireNames = __fields.groupBy(_.wireName).filter(_._2.size > 1).keys.toSeq
     val badIds = ids.intersect(retiredIds)
     val badWireNames = wireNames.intersect(retiredWireNames)
+    if (repeatedWireNames.nonEmpty) {
+      throw new CodegenException("Error: illegal repetition of wire_name's: %s".format(repeatedWireNames.mkString(", ")))
+    }
     if (badIds.nonEmpty) {
       throw new CodegenException("Error: illegal use of retired ids: %s".format(badIds.mkString(", ")))
     }

--- a/src/test/scala/com/foursquare/spindle/codegen/binary/ThriftCodegenTest.scala
+++ b/src/test/scala/com/foursquare/spindle/codegen/binary/ThriftCodegenTest.scala
@@ -1,0 +1,24 @@
+package com.foursquare.spindle.codegen.binary
+
+import com.foursquare.spindle.codegen.runtime.{CodegenException, ScalaProgram}
+import java.io.File
+import org.junit.Assert._
+import org.junit.Test
+
+class ThriftCodegenTest {
+  val base = "src/test/thrift/com/foursquare/spindle/parser"
+
+  @Test
+  def testParseDuplicateWireName(): Unit = {
+    try {
+      val (sources, typeDeclarations, enhancedTypes) = ThriftCodegen.inputInfoForCompiler(
+        Seq(new File(base + "/parse_duplicate_wire_name.thrift")), Seq.empty)
+      val program = ScalaProgram(sources.head, typeDeclarations, enhancedTypes)
+      program.structs.foreach(println _)
+      fail("Parsing duplicate field wire_names should fail.")
+    } catch {
+      case e: CodegenException => ()
+    }
+  }
+
+}

--- a/src/test/scala/com/foursquare/spindle/codegen/binary/build.sbt
+++ b/src/test/scala/com/foursquare/spindle/codegen/binary/build.sbt
@@ -1,0 +1,1 @@
+seq(Default.test: _*)

--- a/src/test/scala/com/foursquare/spindle/codegen/parser/ThriftParserTest.scala
+++ b/src/test/scala/com/foursquare/spindle/codegen/parser/ThriftParserTest.scala
@@ -20,6 +20,16 @@ class ThriftParserTest {
   }
 
   @Test
+  def testParseDuplicateWireName(): Unit = {
+    try {
+      ThriftParser.parseProgram(base + "/parse_duplicate_wire_name.thrift")
+      assertTrue("Parsing duplicate field wire_names should fail.", false)
+    } catch {
+      case e: ParserException => ()
+    }
+  }
+
+  @Test
   def testParseProgram(): Unit = {
     val program = ThriftParser.parseProgram(base + "/parse_program.thrift")
 

--- a/src/test/scala/com/foursquare/spindle/codegen/parser/ThriftParserTest.scala
+++ b/src/test/scala/com/foursquare/spindle/codegen/parser/ThriftParserTest.scala
@@ -20,16 +20,6 @@ class ThriftParserTest {
   }
 
   @Test
-  def testParseDuplicateWireName(): Unit = {
-    try {
-      ThriftParser.parseProgram(base + "/parse_duplicate_wire_name.thrift")
-      assertTrue("Parsing duplicate field wire_names should fail.", false)
-    } catch {
-      case e: ParserException => ()
-    }
-  }
-
-  @Test
   def testParseProgram(): Unit = {
     val program = ThriftParser.parseProgram(base + "/parse_program.thrift")
 

--- a/src/test/scala/com/foursquare/spindle/runtime/GeneratedCodeTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/GeneratedCodeTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 class GeneratedCodeTest {
   private def makePhone(phoneNumberStr: String, phoneType: PhoneType): ContactInfo = {
     val phoneNumberMatch = PhoneNumberUtil.getInstance().findNumbers(phoneNumberStr, "US").iterator().next()
-    val phoneNumber = 
+    val phoneNumber =
       (PhoneNumber
         .newBuilder
         .countryCode(phoneNumberMatch.number.getCountryCode.toShort)
@@ -62,7 +62,7 @@ class GeneratedCodeTest {
         .credits(List("Director", "Writer"))
         .result())
 
-    val movie = 
+    val movie =
       (Movie
         .newBuilder
         .id(new ObjectId("522e3e9f4b90871874292b48"))

--- a/src/test/thrift/com/foursquare/spindle/parser/parse_duplicate_wire_name.thrift
+++ b/src/test/thrift/com/foursquare/spindle/parser/parse_duplicate_wire_name.thrift
@@ -1,0 +1,6 @@
+// Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
+
+struct S {
+  1: i32 a
+  2: i32 b (wire_name="a")
+}


### PR DESCRIPTION
Update ThriftValidator to require that no two fields in a struct share
the same wire_name (and that you can't have wire_name X if there's a
field X with no explicit wire_name).

It's possible this belongs in ScalaClass, not ThriftValidator. Let me know if so.
