### PR TITLE
Update spindle for scala 2.10

### DIFF
--- a/project/Default.scala
+++ b/project/Default.scala
@@ -69,20 +69,10 @@ object Default {
   )
 
   val scala: Seq[Setting[_]] = Default.all ++ Seq(
-    Keys.scalaVersion := "2.9.1",
-    Keys.crossScalaVersions := Seq("2.9.1", "2.9.2", "2.10.2"),
+    Keys.scalaVersion := "2.10.2",
+    Keys.crossScalaVersions := Seq("2.10.2"),
     Keys.scalacOptions <++= (Keys.scalaVersion).map(v => {
-      val opts =
-        Seq(
-          "-deprecation",
-          "-unchecked")
-      if (v.startsWith("2.9.")) {
-        opts ++ Seq(
-          "-Ydependent-method-types",
-          "-Xfatal-warnings")
-      } else {
-        opts
-      }
+      Seq("-deprecation", "-unchecked", "-Xfatal-warnings", "-feature")
     })
   )
 

--- a/src/main/scala/com/foursquare/spindle/codegen/plugin/ThriftCodegenPlugin.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/plugin/ThriftCodegenPlugin.scala
@@ -59,7 +59,7 @@ object ThriftCodegenPlugin extends Plugin {
     )
 
   private def thriftSettings0 = Seq[Project.Setting[_]](
-    thriftCodegenWorkingDir <<= (Keys.crossTarget, Keys.configuration) { (outDir, conf) => 
+    thriftCodegenWorkingDir <<= (Keys.crossTarget, Keys.configuration) { (outDir, conf) =>
       outDir / (Defaults.prefix(conf.name) + "scalate.d")
     },
     Keys.sourceManaged in thrift ~= (_ / "thrift"), // e.g. /target/scala-2.8.1.final/src_managed/main/thrift
@@ -142,7 +142,7 @@ object ThriftCodegenPlugin extends Plugin {
   ): Unit = {
     import streams.log
     val scalaFilesToDelete = (sourceManaged ** "*.scala").get
-    val scalateFilesToDelete = (workingDir ***).get
+    val scalateFilesToDelete = (workingDir.***).get
     val filesToDelete = scalaFilesToDelete ++ scalateFilesToDelete
     log.debug("Cleaning Files:\n%s".format(filesToDelete.mkString("\n")))
     if (scalaFilesToDelete.nonEmpty) {

--- a/src/main/scala/com/foursquare/spindle/runtime/LongNameRecordProxy.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/LongNameRecordProxy.scala
@@ -22,7 +22,7 @@ object TTypeIntrepreter {
   val ByteBufferClass = classOf[ByteBuffer]
 
   def apply(m: Manifest[_]): (Byte, (TProtocol, Any) => Unit) = {
-    m.erasure match {
+    m.runtimeClass match {
       case BooleanClass => (
         JavaTType.BOOL,
         (o: TProtocol, x: Any) => o.writeBool(x.asInstanceOf[Boolean])
@@ -86,13 +86,13 @@ object TTypeIntrepreter {
           o.writeSetEnd
         })
       }
-      case _ if manifest[Enum[_]].erasure.isAssignableFrom(m.erasure) => (
+      case _ if manifest[Enum[_]].runtimeClass.isAssignableFrom(m.runtimeClass) => (
         JavaTType.ENUM,
         (o: TProtocol, x: Any) => {
           o.writeString(x.asInstanceOf[Enum[_]].name)
         }
       )
-      case _ if manifest[TBase[_, _]].erasure.isAssignableFrom(m.erasure) => (
+      case _ if manifest[TBase[_, _]].runtimeClass.isAssignableFrom(m.runtimeClass) => (
         JavaTType.STRUCT,
         (o: TProtocol, x: Any) => {
           val tbase = x.asInstanceOf[TBase[_, _] with Record[_]]
@@ -102,7 +102,7 @@ object TTypeIntrepreter {
       // TODO(dan): ObjectId, DateTime and all the other enhanced fields.
       case _ => (
         JavaTType.VOID,
-        (o: TProtocol, x: Any) => throw new TException("Unsupported type: " + m.erasure.getName)
+        (o: TProtocol, x: Any) => throw new TException("Unsupported type: " + m.runtimeClass.getName)
       )
     }
   }

--- a/src/main/ssp/codegen/scala/class_impls_hashcode.ssp
+++ b/src/main/ssp/codegen/scala/class_impls_hashcode.ssp
@@ -1,13 +1,17 @@
 <%
   // Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
 
-  import com.foursquare.spindle.codegen.runtime.StructLike 
+  import com.foursquare.spindle.codegen.runtime.StructLike
 %>
 <%@ val cls: StructLike %>
   override def hashCode(): Int = {
-    val hasher = new scala.util.MurmurHash[AnyRef](0)  // We use a fixed seed, for consistency.
+    var hash: Int = 0   // We use a fixed seed, for consistency
+    var length: Int = 0
 #for (field <- cls.fields)
-    if (${field.isSetName}) hasher.append(${field.varName}.##)
+    if (${field.isSetName}) {
+      hash = scala.util.hashing.MurmurHash3.mix(hash, ${field.varName}.##)
+      length += 1
+    }
 #end
-    hasher.hash
+    scala.util.hashing.MurmurHash3.finalizeHash(hash, length)
   }


### PR DESCRIPTION
Notably, the generated code spews a lot of warnings when compiled
under scala 2.10, because of the use of MurmurHash. Switching to
MurmurHash3 fixes these warnings.

If we want to maintain compatibility with 2.9, we would need to
pass through the target compile version and generate different
code for each version.
