### PR TITLE
Support for mongo 2.4 index types

### DIFF
--- a/src/main/scala/com/foursquare/spindle/runtime/IndexParser.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/IndexParser.scala
@@ -29,7 +29,9 @@ object IndexParser {
         case "1" | "asc" | "ascending" => Right("1")
         case "-1" | "desc" | "descending" => Right("-1")
         case "2d" | "twod" => Right("2d")
+        case "2dsphere" => Right("2dsphere")
         case "hashed" => Right("hashed")
+        case "text" => Right("text")
         case indexSpecifier => Left(InvalidIndex(indexSpecifier))
       }
 

--- a/src/main/scala/com/foursquare/spindle/runtime/IndexParser.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/IndexParser.scala
@@ -29,6 +29,7 @@ object IndexParser {
         case "1" | "asc" | "ascending" => Right("1")
         case "-1" | "desc" | "descending" => Right("-1")
         case "2d" | "twod" => Right("2d")
+        case "hashed" => Right("hashed")
         case indexSpecifier => Left(InvalidIndex(indexSpecifier))
       }
 


### PR DESCRIPTION
Mongo introduced text, hashed, and 2dsphere indexes. There's also a geoHaystack index, but that's a two-part index  that I'm not sure how to add just yet. Issuing this pull request for the others for now.
