### PR TITLE
Test to expose a regression in handling enhanced types.

### DIFF
--- a/src/test/scala/com/foursquare/spindle/runtime/EnhancedTypesTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/EnhancedTypesTest.scala
@@ -1,0 +1,62 @@
+// Copyright 2014 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.spindle.runtime.test
+
+import com.foursquare.spindle.test.gen.MapWithObjectIdKeys
+import org.bson.types.ObjectId
+import org.apache.thrift.TBase
+import org.apache.thrift.transport.{TTransport, TMemoryBuffer}
+import com.foursquare.spindle.runtime.{KnownTProtocolNames, TProtocolInfo}
+
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+
+class EnhancedTypesTest {
+
+  @Test
+  def testObjectIdMapKeys() {
+    val protocols =
+      KnownTProtocolNames.TBinaryProtocol ::
+      KnownTProtocolNames.TCompactProtocol ::
+      KnownTProtocolNames.TJSONProtocol ::
+      KnownTProtocolNames.TBSONProtocol ::
+      KnownTProtocolNames.TReadableJSONProtocol ::
+      Nil
+
+    for (tproto <- protocols) {
+      println("Testing enhanced types for protocol %s".format(tproto))
+      doTestObjectIdMapKeys(tproto)
+    }
+  }
+
+  private def doTestObjectIdMapKeys(tproto: String) {
+    val m = Map(new ObjectId() -> 4.5, new ObjectId() -> 33.7)
+    val struct = MapWithObjectIdKeys.newBuilder.foo(m).result()
+
+    // Write the object out.
+    val buf = doWrite(tproto, struct)
+
+    // Read the new object into an older version of the same struct.
+    val roundtrippedStruct = MapWithObjectIdKeys.createRawRecord.asInstanceOf[TBase[_, _]]
+    doRead(tproto, buf, roundtrippedStruct)
+
+    assertEquals(struct, roundtrippedStruct)
+  }
+
+
+  private def doWrite(protocolName: String, thriftObj: TBase[_, _]): TMemoryBuffer = {
+    val protocolFactory = TProtocolInfo.getWriterFactory(protocolName)
+    val trans = new TMemoryBuffer(1024)
+    val oprot = protocolFactory.getProtocol(trans)
+    thriftObj.write(oprot)
+    trans
+  }
+
+  private def doRead(protocolName: String, trans: TTransport, thriftObj: TBase[_, _]) {
+    val protocolFactory = TProtocolInfo.getReaderFactory(protocolName)
+    val iprot = protocolFactory.getProtocol(trans)
+    thriftObj.read(iprot)
+  }
+}

--- a/src/test/thrift/com/foursquare/spindle/codegen/enhanced_types_test.thrift
+++ b/src/test/thrift/com/foursquare/spindle/codegen/enhanced_types_test.thrift
@@ -1,0 +1,9 @@
+// Copyright 2014 Foursquare Labs Inc. All Rights Reserved.
+
+namespace java com.foursquare.spindle.test.gen
+
+typedef binary (enhanced_types="bson:ObjectId") ObjectId
+
+struct MapWithObjectIdKeys {
+  1: optional map<ObjectId, double> foo
+}


### PR DESCRIPTION
The enhanced_types annotation is somehow not being propagated
to the generated code. This breaks TBSONProtocol and TReadableJSONProtocol.

A future change will include a fix. For now it's better to have a broken test
in master than code that seems like it works but doesn't.
