### PR TITLE
Fix non-string map key issues in BSON/JSON protos.

### DIFF
--- a/src/main/java/com/foursquare/common/thrift/base/NonStringMapKeyException.java
+++ b/src/main/java/com/foursquare/common/thrift/base/NonStringMapKeyException.java
@@ -1,0 +1,10 @@
+package com.foursquare.common.thrift.base;
+
+
+import org.apache.thrift.TException;
+
+public class NonStringMapKeyException extends TException {
+  public NonStringMapKeyException(Object key) {
+    super("Protocol requires string-typed map key, but got a " + key.getClass().getCanonicalName());
+  }
+}

--- a/src/main/java/com/foursquare/common/thrift/bson/BSONWriteState.java
+++ b/src/main/java/com/foursquare/common/thrift/bson/BSONWriteState.java
@@ -2,6 +2,7 @@
 
 package com.foursquare.common.thrift.bson;
 
+import com.foursquare.common.thrift.base.NonStringMapKeyException;
 import com.mongodb.BasicDBList;
 
 import java.util.EmptyStackException;
@@ -42,7 +43,7 @@ class BSONWriteState<B extends BSONObject> {
           currentKey = null;
         }
       } catch (ClassCastException e) {
-        throw new TException("Expected string document key but got a " + item.getClass().getName());
+        throw new NonStringMapKeyException(item);
       }
     }
   }

--- a/src/main/ssp/codegen/scala/class_impls_tostring.ssp
+++ b/src/main/ssp/codegen/scala/class_impls_tostring.ssp
@@ -9,7 +9,7 @@
     val indenter = new org.codehaus.jackson.util.DefaultPrettyPrinter.FixedSpaceIndenter
     val pp = new org.codehaus.jackson.util.DefaultPrettyPrinter
     pp.indentObjectsWith(indenter)
-    val oprot = new com.foursquare.common.thrift.json.TReadableJSONProtocol(trans, pp)
+    val oprot = new com.foursquare.common.thrift.json.TReadableJSONProtocol(trans, pp, null, true)
     write(oprot)
     trans.toString("UTF8")
   }

--- a/src/test/scala/com/foursquare/spindle/runtime/EnhancedTypesTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/EnhancedTypesTest.scala
@@ -2,7 +2,7 @@
 
 package com.foursquare.spindle.runtime.test
 
-import com.foursquare.spindle.test.gen.MapWithObjectIdKeys
+import com.foursquare.spindle.test.gen.ObjectIdFields
 import org.bson.types.ObjectId
 import org.apache.thrift.TBase
 import org.apache.thrift.transport.{TTransport, TMemoryBuffer}
@@ -16,7 +16,7 @@ import org.junit.Test
 class EnhancedTypesTest {
 
   @Test
-  def testObjectIdMapKeys() {
+  def testObjectIdFields() {
     val protocols =
       KnownTProtocolNames.TBinaryProtocol ::
       KnownTProtocolNames.TCompactProtocol ::
@@ -27,19 +27,22 @@ class EnhancedTypesTest {
 
     for (tproto <- protocols) {
       println("Testing enhanced types for protocol %s".format(tproto))
-      doTestObjectIdMapKeys(tproto)
+      doTestObjectIdFields(tproto)
     }
   }
 
-  private def doTestObjectIdMapKeys(tproto: String) {
-    val m = Map(new ObjectId() -> 4.5, new ObjectId() -> 33.7)
-    val struct = MapWithObjectIdKeys.newBuilder.foo(m).result()
+  private def doTestObjectIdFields(tproto: String) {
+    val struct = ObjectIdFields.newBuilder
+      .foo(new ObjectId())
+      .bar(new ObjectId() :: new ObjectId() :: Nil)
+      .baz(Map("A" -> new ObjectId(), "B" -> new ObjectId()))
+      .result()
 
     // Write the object out.
     val buf = doWrite(tproto, struct)
 
     // Read the new object into an older version of the same struct.
-    val roundtrippedStruct = MapWithObjectIdKeys.createRawRecord.asInstanceOf[TBase[_, _]]
+    val roundtrippedStruct = ObjectIdFields.createRawRecord.asInstanceOf[TBase[_, _]]
     doRead(tproto, buf, roundtrippedStruct)
 
     assertEquals(struct, roundtrippedStruct)

--- a/src/test/scala/com/foursquare/spindle/runtime/MapKeysTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/MapKeysTest.scala
@@ -1,0 +1,36 @@
+// Copyright 2014 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.spindle.runtime.test
+
+import org.apache.thrift.transport.TMemoryBuffer
+import org.junit.Test
+
+import com.foursquare.common.thrift.base.NonStringMapKeyException
+import com.foursquare.spindle.runtime.{KnownTProtocolNames, TProtocolInfo}
+import com.foursquare.spindle.test.gen.MapWithI32Keys
+
+
+class MapKeysTest {
+
+  @Test(expected=classOf[NonStringMapKeyException])
+  def testBSONStringOnlyMapKeys() {
+    doTestStringOnlyMapKeys(KnownTProtocolNames.TBSONProtocol)
+  }
+
+  @Test(expected=classOf[NonStringMapKeyException])
+  def testTReadableJSONStringOnlyMapKeys() {
+    doTestStringOnlyMapKeys(KnownTProtocolNames.TReadableJSONProtocol)
+  }
+
+  private def doTestStringOnlyMapKeys(tproto: String) {
+    val struct = MapWithI32Keys.newBuilder
+      .foo(Map(123 -> "A", 456 -> "B"))
+      .result()
+
+    // Attempt to write the object out.
+    val protocolFactory = TProtocolInfo.getWriterFactory(tproto)
+    val trans = new TMemoryBuffer(1024)
+    val oprot = protocolFactory.getProtocol(trans)
+    struct.write(oprot)  // Expected to throw NonStringMapKeyException.
+  }
+}

--- a/src/test/scala/com/foursquare/spindle/runtime/ToStringTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/ToStringTest.scala
@@ -1,0 +1,26 @@
+// Copyright 2014 Foursquare Labs Inc. All Rights Reserved.
+
+package com.foursquare.spindle.runtime.test
+
+import org.bson.types.ObjectId
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import com.foursquare.spindle.test.gen.MapsWithNonStringKeys
+
+
+class ToStringTest {
+
+  @Test
+  def testToString() {
+    val struct = MapsWithNonStringKeys.newBuilder
+      .foo(Map(123 -> "A", 456 -> "B"))
+      .bar(Map(new ObjectId("000102030405060708090a0b") -> 77,
+               new ObjectId("0c0d0e0f1011121314151617") -> 42))
+      .result()
+
+    val expected =
+      """{ "foo" : { "123" : "A", "456" : "B" }, "bar" : { "ObjectId(\"000102030405060708090a0b\")" : 77, "ObjectId(\"0c0d0e0f1011121314151617\")" : 42 } }"""
+    val str = struct.toString()
+    assertEquals(expected, str)
+  }
+}

--- a/src/test/thrift/com/foursquare/spindle/codegen/map_keys_test.thrift
+++ b/src/test/thrift/com/foursquare/spindle/codegen/map_keys_test.thrift
@@ -1,0 +1,8 @@
+// Copyright 2014 Foursquare Labs Inc. All Rights Reserved.
+
+namespace java com.foursquare.spindle.test.gen
+
+
+struct MapWithI32Keys {
+  1: optional map<i32, string> foo
+}

--- a/src/test/thrift/com/foursquare/spindle/codegen/to_string_test.thrift
+++ b/src/test/thrift/com/foursquare/spindle/codegen/to_string_test.thrift
@@ -4,8 +4,7 @@ namespace java com.foursquare.spindle.test.gen
 
 typedef binary (enhanced_types="bson:ObjectId") ObjectId
 
-struct ObjectIdFields {
-  1: optional ObjectId foo
-  2: optional list<ObjectId> bar
-  3: optional map<string, ObjectId> baz
+struct MapsWithNonStringKeys {
+  1: optional map<i32, string> foo
+  2: optional map<ObjectId, i32> bar
 }


### PR DESCRIPTION
This change:
1. Enforces that map keys are strings.
2. Allows a "coerce" mode in TJSONProtocol where map keys are
    coerced to strings. This is used only in the implementation
    of toString() on records, which just JSON-serialized, and must
    work on all structs, even ones with non-string-key maps.
3. Adds various tests around this.
