### PR TITLE
Handle unknown enumerators seen on the wire.

### DIFF
--- a/src/main/scala/com/foursquare/spindle/codegen/runtime/TypeReferenceResolver.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/runtime/TypeReferenceResolver.scala
@@ -62,6 +62,7 @@ class TypeReferenceResolver(
       case SimpleBaseType.DOUBLE => DoubleRef
       case SimpleBaseType.STRING => StringRef
       case SimpleBaseType.BINARY => BinaryRef
+      case u: SimpleBaseType.Unknown => throw new IllegalStateException("Invalid SimpleBaseType")
     }
   }
 

--- a/src/main/scala/com/foursquare/spindle/runtime/Enum.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/Enum.scala
@@ -19,6 +19,8 @@ abstract class EnumMeta[T <: Enum[T]] {
   def findByIdOrNull(id: Int): T
   def findByNameOrNull(name: String): T
 
+  def findByIdOrUnknown(id: Int): T
+
   def findById(id: Int): Option[T] = Option(findByIdOrNull(id))
   def findByName(name: String): Option[T] = Option(findByNameOrNull(name))
 

--- a/src/main/ssp/codegen/scala/enum.ssp
+++ b/src/main/ssp/codegen/scala/enum.ssp
@@ -34,6 +34,8 @@ object ${enum.name} extends com.foursquare.spindle.EnumMeta[${enum.name}] {
   object ${elem.name} extends ${enum.name}(${elem.value.toString}, "${elem.name}", "${alt}")
 #end
 
+  final class Unknown(id: Int) extends ${enum.name}(id, "", "")
+
   override val values: Vector[${enum.name}] =
     Vector(
       ${enum.elements.map(_.name).mkString(",\n      ")}
@@ -44,6 +46,11 @@ object ${enum.name} extends com.foursquare.spindle.EnumMeta[${enum.name}] {
     case ${elem.value.toString} => ${elem.name}
 #end
     case _ => null
+  }
+
+  override def findByIdOrUnknown(id: Int): ${enum.name} = findByIdOrNull(id) match {
+    case null => new Unknown(id)
+    case x: ${enum.name} => x
   }
 
   override def findByNameOrNull(name: String): ${enum.name} = name match {

--- a/src/main/ssp/codegen/scala/read/enum.ssp
+++ b/src/main/ssp/codegen/scala/read/enum.ssp
@@ -3,4 +3,4 @@
 <%@ val indent: String %>
 <%@ val wrapLeft: String = "" %>
 <%@ val wrapRight: String = "" %>
-${indent}${lhs} ${wrapLeft}${renderType.text}.findByIdOrNull(iprot.readI32())${wrapRight}
+${indent}${lhs} ${wrapLeft}${renderType.text}.findByIdOrUnknown(iprot.readI32())${wrapRight}


### PR DESCRIPTION
They will be read into a special 'Unknown' subclass of the enum sealed base class. 

Note that the base class is sealed, so this will break all matches on enums that don't have a case _ =>. All such matches will need to be updated to handle this Unknown case.
