### PR TITLE
Loosen the access restriction for multiple methods, fields and classes so people could inherit them and override part of the logic

### DIFF
--- a/src/main/java/com/foursquare/common/thrift/bson/TBSONProtocol.java
+++ b/src/main/java/com/foursquare/common/thrift/bson/TBSONProtocol.java
@@ -25,7 +25,7 @@ import org.bson.BasicBSONEncoder;
  */
 public class TBSONProtocol extends TBSONObjectProtocol {
   // Our superclass uses a dummy transport, and we mediate its input/output from/to this transport.
-  private TTransport realTransport;
+  protected TTransport realTransport;
 
   /**
    * Factory for protocol objects used for serializing BSON.


### PR DESCRIPTION
Here is the rational for this pull request:

in spindle, you guys are relied on the wired_name annotation to serialize and deserialize, which is a good way to solve the problem. However, there is two limitation:
1. more storage are needed for db
2. the bson library would not work with other thrift code generator, such as scrooge.

So the way I want to use is to use the field id as the key when read and write mongodb, e.g

```
struct {
   1: string name
   2: int age
}
```

would be like

```
{1: xxx, 2: 18}
```

 in database, though it's less obvious, sometime you need to reference the thrift file to understand the meaning. but it is robust and enough.

So I need to change the logic of read and write and I don't think directly change BSONReadState and TBSONProtocol is a good idea.Therefore I want to change the access restriction for several fields so I could inherit and override part of the logic.

e.g. here is how I want to read:
https://github.com/lambda-initiative/thriftdao/blob/master/src/main/java/com/lambdai/thriftdao/bson/LBSONReadState.java#L18

and how I write:
https://github.com/lambda-initiative/thriftdao/blob/master/src/main/java/com/lambdai/thriftdao/bson/LTBSONProtocol.java#L47
