### PR TITLE
Annotate proxies needed for Thrift descriptors

### DIFF
--- a/project/Default.scala
+++ b/project/Default.scala
@@ -8,7 +8,7 @@ import sbt._
 object Default {
   val all: Seq[Setting[_]] = Seq(
     Keys.target <<= (Keys.name)(name => Path.absolute(file("target") / name)),
-    Keys.version := "2.0.0-M7",
+    Keys.version := "2.0.0-M8-SNAPSHOT",
     Keys.organization := "com.foursquare",
     Keys.publishMavenStyle := true,
     Keys.publishArtifact in Test := false,

--- a/src/main/scala/com/foursquare/spindle/codegen/plugin/ThriftCodegenPlugin.scala
+++ b/src/main/scala/com/foursquare/spindle/codegen/plugin/ThriftCodegenPlugin.scala
@@ -26,7 +26,7 @@ object ThriftCodegenPlugin extends Plugin {
     }),
     thriftCodegenTemplate := "scala/record.ssp",
     thriftCodegenAllowReload := false,
-    thriftCodegenVersion := "2.0.0-M7",
+    thriftCodegenVersion := "2.0.0-M8-SNAPSHOT",
     thriftCodegenBinaryLibs <<= (thriftCodegenVersion, Keys.scalaBinaryVersion in thrift)((cv, bv) =>
         Seq("com.foursquare" % ("spindle-codegen-binary_" + bv) % cv)
     ),

--- a/src/main/thrift/com/twitter/thrift/descriptors/thrift_descriptors.thrift
+++ b/src/main/thrift/com/twitter/thrift/descriptors/thrift_descriptors.thrift
@@ -117,7 +117,7 @@ struct Typedef {
   1: required string typeId,
   2: required string typeAlias,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 // A registry of all the types referenced in a thrift program.
 //
@@ -139,7 +139,7 @@ struct Const {
   1: required string typeId,
   2: required string name,
   3: required string value
-}
+} (generate_proxy="true")
 
 
 /* Enumerations. */
@@ -148,13 +148,13 @@ struct EnumElement {
   1: required string name,
   2: required i32 value,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 struct Enum {
   1: required string name,
   2: required list<EnumElement> elements,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 
 /* Structs, unions and exceptions. */
@@ -171,25 +171,25 @@ struct Field {
   4: optional Requiredness requiredness,
   5: optional string defaultValue,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 struct Struct {
   1: required string name,
   2: required list<Field> fields,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 struct Union {
   1: required string name,
   2: required list<Field> fields,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 struct Exception {
   1: required string name,
   2: required list<Field> fields,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 
 /* Services. */
@@ -201,14 +201,14 @@ struct Function {
   4: required list<Field> argz,
   5: required list<Field> throwz,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 struct Service {
   1: required string name,
   2: optional string extendz,
   3: required list<Function> functions,
   99: optional list<Annotation> annotations = []
-}
+} (generate_proxy="true")
 
 
 // In the Thrift parsing code the collection of all elements in a .thrift file
@@ -226,4 +226,4 @@ struct Program {
 
   // A registry of all types in the program. Used for resolving type references.
   98: required TypeRegistry typeRegistry
-}
+} (generate_proxy="true")


### PR DESCRIPTION
In preparation for upgrading the bootstrapped version of the codegen binary. (No actual upgrade of it yet though.)
