### PR TITLE
add more to base interfaces

### DIFF
--- a/src/main/scala/com/foursquare/spindle/runtime/MetaRecord.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/MetaRecord.scala
@@ -15,7 +15,7 @@ trait MetaRecord[R <: Record[R]] extends UntypedMetaRecord {
   type Raw <: R
 
   def recordName: String
-  def createRawRecord: Raw
+  def createRawRecord: Raw with MutableRecord[R]
   def fields: Seq[FieldDescriptor[_, R, this.type]]
   def ifInstanceFrom(x: AnyRef): Option[R]
 }

--- a/src/main/scala/com/foursquare/spindle/runtime/Record.scala
+++ b/src/main/scala/com/foursquare/spindle/runtime/Record.scala
@@ -11,6 +11,12 @@ trait UntypedRecord {
   def write(oprot: TProtocol): Unit
 }
 
-trait Record[R <: Record[R]] extends UntypedRecord { self: R =>
+trait Record[R <: Record[R]] extends UntypedRecord with scala.Ordered[R] { self: R =>
   def meta: MetaRecord[R]
+
+  def mergeCopy(that: R): R
+}
+
+trait MutableRecord[R <: Record[R]] { self: R =>
+  def merge(that: R): Unit
 }

--- a/src/main/ssp/codegen/scala/class_traits.ssp
+++ b/src/main/ssp/codegen/scala/class_traits.ssp
@@ -17,7 +17,6 @@ trait ${cls.name}
 #for (pkField <- cls.primaryKeyField)
     with com.foursquare.spindle.HasPrimaryKey[${pkField.renderType.text}, ${cls.name}]
 #end
-    with scala.Ordered[${cls.name}]
     with org.apache.thrift.TBase[${cls.name}, ${cls.name}._Fields] {
 
 #for (field <- cls.fields)

--- a/src/main/ssp/codegen/scala/class_traits_mutablet.ssp
+++ b/src/main/ssp/codegen/scala/class_traits_mutablet.ssp
@@ -1,10 +1,11 @@
 <%
   // Copyright 2013 Foursquare Labs Inc. All Rights Reserved.
 
-  import com.foursquare.spindle.codegen.runtime.StructLike 
+  import com.foursquare.spindle.codegen.runtime.StructLike
 %>
 <%@ val cls: StructLike %>
-trait Mutable${cls.name} extends ${cls.name} {
+trait Mutable${cls.name} extends ${cls.name}
+  with com.foursquare.spindle.MutableRecord[${cls.name}] {
 #for (field <- cls.fields)
 <% render(field.renderType.fieldMutableTemplate, Map("field" -> field)) %>
 #end


### PR DESCRIPTION
Generally the goal of this makes the base interfaces more usable. The
specific goal is to allow for a generic joining Reducer that could
create a record and then merge() all the values in that reducer group,
but I'm moving up a couple other common methods at the same time.
- make Record inherit from scala.Ordered[R] to expose compare
- add mergeCopy(R): R to Record
- create a MutableRecord mixin that Mutable and Raw records will always
  have, and add merge(R): Unit to it.
