### PR TITLE
Add Futurepool arg to ServiceToClient

### DIFF
--- a/src/main/ssp/codegen/scala/service.ssp
+++ b/src/main/ssp/codegen/scala/service.ssp
@@ -178,8 +178,16 @@ object ${service.name} extends com.foursquare.spindle.ServiceDescriptor {
 <%-- ServiceToClient adapter --%>\
   class ServiceToClient(
       service: com.twitter.finagle.Service[com.twitter.finagle.thrift.ThriftClientRequest, Array[Byte]],
-      protocolFactory: org.apache.thrift.protocol.TProtocolFactory
+      protocolFactory: org.apache.thrift.protocol.TProtocolFactory,
+      deserializationPoolOpt: Option[com.twitter.util.FuturePool]
   ) extends #if (parentServiceName != "")${parentServiceName}.ServiceToClient(service, protocolFactory) with ServiceIface #(else)ServiceIface#(end) {
+    <%-- Note: Can't use default param because Twitter's
+    finagle Thrift Iface constructor finder expects 2 args  --%>
+    def this(
+      service: com.twitter.finagle.Service[com.twitter.finagle.thrift.ThriftClientRequest, Array[Byte]],
+      protocolFactory: org.apache.thrift.protocol.TProtocolFactory
+    ) = this(service, protocolFactory, None)
+
 #for (function <- service.functions)
 
     override <% render("service_funcsig.ssp", Map("function" -> function, "resolver" -> resolver,
@@ -210,7 +218,12 @@ object ${service.name} extends com.foursquare.spindle.ServiceDescriptor {
 #(end)
             com.twitter.util.Future.value(null) <%-- Thrift compiler uses null. --%>
 #else
-            com.twitter.util.Future.value((new Client(__prot__)).recv_${function.name}())
+            val __client__ = (new Client(__prot__))
+            deserializationPoolOpt.map(__deserializationPool__ =>
+              __deserializationPool__.apply(__client__.recv_${function.name}())
+            ).getOrElse(
+              com.twitter.util.Future.value(__client__.recv_${function.name}())
+            )
 #end
           } catch {
             case e: Exception => com.twitter.util.Future.exception(e)

--- a/src/test/scala/com/foursquare/spindle/runtime/ServicesTest.scala
+++ b/src/test/scala/com/foursquare/spindle/runtime/ServicesTest.scala
@@ -5,22 +5,30 @@ package com.foursquare.spindle.test
 import com.foursquare.spindle.test.gen.AService
 import com.twitter.conversions.time._
 import com.twitter.finagle.Thrift
-import com.twitter.util.{Await, Future, Promise}
+import com.twitter.util.{Await, Future, FuturePool, Promise}
 import java.net.InetSocketAddress
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ServicesTest {
-  
+
   @Test
   def testServices() {
     var voidMethodCounter = 0
     var oneWayVoidMethodCounter = 0
+    var futurePoolExecutionCounter = 0
 
     val firstBarrierPromise = new Promise[Unit]
     val secondBarrierPromise = new Promise[Unit]
 
-  	val server = Thrift.serveIface(":*", new AService.ServiceIface {
+    val testDeserializationPool = new FuturePool {
+      def apply[T](f: => T): Future[T] = {
+        futurePoolExecutionCounter += 1
+        Future(f)
+      }
+    }
+
+    val server = Thrift.serveIface(":*", new AService.ServiceIface {
       def voidMethod(): com.twitter.util.Future[Unit] = {
         voidMethodCounter += 1
         Future.Done
@@ -36,10 +44,16 @@ class ServicesTest {
       def add(x: Int, y: Int): com.twitter.util.Future[Int] = {
         Future.value(x + y)
       }
-  	})
+    })
 
     try {
       val client = Thrift.newIface[AService.ServiceIface](server)
+
+      val deserializationPoolClient = {
+        val service = Thrift.newClient(server).toService
+        new AService.ServiceToClient(service, Thrift.protocolFactory, Some(testDeserializationPool))
+      }
+
 
       // Test that we can pass parameters.
       for ((x, y) <- Seq((60, 40), (-60, 40), (-60, -40), (60, 0), (-60, 0), (0, 40), (0, -40))) {
@@ -47,20 +61,27 @@ class ServicesTest {
         assertEquals(result, x + y)
       }
 
+
+      assertEquals(0, futurePoolExecutionCounter)
+      val deserializationPoolResult = Await.result(deserializationPoolClient.add(60, 40), 2.seconds)
+      assertEquals(1, futurePoolExecutionCounter)
+      assertEquals(100, deserializationPoolResult)
+
+
       // Test that a void method does not return until it has performed its work.
       Await.result(client.voidMethod(), 2.seconds)
-      assertEquals(voidMethodCounter, 1)
+      assertEquals(1, voidMethodCounter)
 
       // Test that a one-way function returns immediately and that the function completes asynchronously.
       // This fact is tested using two barriers to make sure that oneWayVoidMethod cannot perform its
       // work until released by the main test thread.
       Await.result(client.oneWayVoidMethod(), 2.seconds)
-      assertEquals(oneWayVoidMethodCounter, 0)
+      assertEquals(0, oneWayVoidMethodCounter)
       firstBarrierPromise.setValue(())
       Await.ready(secondBarrierPromise, 2.seconds)
-      assertEquals(oneWayVoidMethodCounter, 1)
+      assertEquals(1, oneWayVoidMethodCounter)
     } finally {
       Await.ready(server.close(), 2.seconds)
     }
   }
-}      
+}


### PR DESCRIPTION
If you want to have your Array[Byte] -> Thrift
deserialization to happen on a FuturePool, maybe
because it is very large or nested or something,
you can now pass in a FuturePool argument.

The existing 2-arg constructor was preserved so that
Thrift.newIface continues to work.
